### PR TITLE
Update Python virtual environment path and permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,11 @@ COPY --chown=rstudio:rstudio /.vscode/_settings.json /home/rstudio/.vscode-serve
 RUN R -e "install.packages(c('renv'))"
 
 # Python
-RUN python3 -m venv /home/rstudio/venv && \
-    /home/rstudio/venv/bin/pip install --upgrade pip setuptools && \
-    /home/rstudio/venv/bin/pip install jupyter dvc
+RUN python3 -m venv /home/rstudio/.cache/venv && \
+    /home/rstudio/.cache/venv/bin/pip install --upgrade pip setuptools && \
+    /home/rstudio/.cache/venv/bin/pip install jupyter dvc
 
-ENV PATH="/home/rstudio/venv/bin:$PATH"
-
-RUN chown -R rstudio:rstudio /home/rstudio/venv
+ENV PATH="/home/rstudio/.cache/venv/bin:$PATH"
 
 # Julia
 ENV JULIA_MINOR_VERSION=1.11
@@ -53,5 +51,5 @@ RUN wget -O quarto.deb https://github.com/quarto-dev/quarto-cli/releases/downloa
     rm quarto.deb
 
 # Package Cahce & Permission
-RUN cd /home/rstudio && mkdir .cache .TinyTeX && \
-    chown rstudio:rstudio .cache .TinyTeX
+RUN cd /home/rstudio && mkdir -p .cache .TinyTeX && \
+    chown -R rstudio:rstudio .cache .TinyTeX

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,20 +8,16 @@ services:
             - LC_ALL=ja_JP.UTF-8
             - TZ=Asia/Tokyo
             - DISABLE_AUTH=true
-            - PYTHONUSERBASE=/home/rstudio/.pip
             - JULIA_DEPOT_PATH=/home/rstudio/.cache/julia
         volumes:
             - .:/home/rstudio/work
             - cache:/home/rstudio/.cache
             - TinyTeX:/home/rstudio/.TinyTeX
             - fonts:/usr/share/fonts
-            - pip:/home/rstudio/.pip
 volumes:
   cache:
     external: true
   TinyTeX:
     external: true
   fonts:
-    external: true
-  pip:
     external: true


### PR DESCRIPTION
Change the Python virtual environment path to a cache directory and adjust permissions for the cache and TinyTeX directories. Remove unnecessary volume references for pip.